### PR TITLE
fix wrong documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ describe('User', () => {
 });
 ```
 
-Take a look at our [documentation](https://goldziher.github.io/interfaceForge/) or read
+Take a look at our [documentation](https://goldziher.github.io/interface-forge/) or read
 the [introduction article](https://javascript.plainenglish.io/generating-test-data-and-fixtures-with-interface-forge-5a5548233aa5)
 .
 


### PR DESCRIPTION
as title