### PR TITLE
Bugfix/release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,20 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Install Node.js
+              uses: actions/setup-node@v3
               with:
-                  node-version: '16.x'
-                  registry-url: 'https://registry.npmjs.org'
-            - run: yarn install
-            - run: yarn build
-            - run: yarn publish
+                  node-version: 18
+            - uses: pnpm/action-setup@v2.2.4
+              name: Install pnpm
+              id: pnpm-install
+              with:
+                  version: 7
+            - name: Install Dependencies
+              run: pnpm install
+            - run: pnpm build
+            - run: npm publish
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/
 *.log
 _/
 .idea/
+.DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.fixAll": true
+    },
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
             "email": "mail@damiankress.de"
         }
     ],
-    "version": "1.5.0",
+    "version": "1.5.1",
     "license": "MIT",
     "description": "Gracefully generate testing data using TypeScript",
     "keywords": [


### PR DESCRIPTION
Hopefully this fixes 1. in #22:

In the [release.yaml](https://github.com/Goldziher/interface-forge/blob/main/.github/workflows/release.yml) the switch has not been made to pnpm – `yarn` is still being used to install and publish.
I copied over the pnpm checkout and install steps from the main.yaml, but I changed `yarn publish` to `npm publish`.
`pnpm publish` probably also works, but in my experience using `npm` to publish is the most reliable way.